### PR TITLE
fix(api): add support for validating response from faq

### DIFF
--- a/src/CorosApi.ts
+++ b/src/CorosApi.ts
@@ -133,8 +133,11 @@ export default class CorosApi {
   }
 
   private validateApiResponse<T extends CorosCommonResponse>(response: T): T {
-    if (response.result !== ResponseCodes.Success) {
+    if ('result' in response && response.result !== ResponseCodes.Success) {
       throw new Error(`Coros API error: ${response.message} (code: ${response.result})`);
+    }
+    else if ('code' in response && response.code !== 200) {
+      throw new Error(`Coros API error: ${response.message} (HTTP code: ${response.code})`);
     }
     return response;
   }

--- a/src/CorosApi.ts
+++ b/src/CorosApi.ts
@@ -77,6 +77,7 @@ export default class CorosApi {
       this._stsConfig = config.stsConfig;
       if (config.stsConfig === STSConfigs.EU) {
         this._apiUrl = EU_API_URL;
+        this._sign = "877571111A1EE5316E4B590103D4B5B3";
       }
     }
     if (config.apiUrl) this._apiUrl = config.apiUrl;


### PR DESCRIPTION
Hi! I'm using eu instance of coros but it will probably works on other also. Uploading files didn't work so I investigated and found out that https://faq.coros.com/openapi/oss/sts?bucket=eu-coros&service=aws&v=2&app_id=1660188068672619112&sign=877571111A1EE5316E4B590103D4B5B3 returns:
```
{"msg":"success","code":200,"data":{"credentials":"<credentials>","v":"2"},"module":null}
```
so there is no `result` field in this object to check and code was throwing exception even if query was successful and returned 200.

I also had to change sign for EU so it probably makes sense to put it inside code.